### PR TITLE
python client method to check camera existence

### DIFF
--- a/pythonAPIClient/client.py
+++ b/pythonAPIClient/client.py
@@ -467,6 +467,8 @@ class Client(object):
                 raise AuthenticationError(response.json()['message'])
             elif response.status_code == 422:
                 raise FormatError(response.json()['message'])
+            elif response.status_code == 404:
+                raise FormatError(response.json()['message'])
             else:
                 raise InternalError()
         camera_response_array = response.json()

--- a/pythonAPIClient/client.py
+++ b/pythonAPIClient/client.py
@@ -420,7 +420,7 @@ class Client(object):
 
         return camera_processed
 
-    def cam_match(self, camera_type, **kwargs):
+    def check_cam_exist(self, camera_type, **kwargs):
         """
         A method to get one or more camera object that has the given retrieval method
         in the database.
@@ -447,12 +447,12 @@ class Client(object):
 
         Returns
         -------
-        :list
+        :obj:`list` of :obj:`Camera`
             List of camera objects that has the given retrieval method. If there ar eno cameras
             matches the provided retrieval information, an empty list will be returned.
 
         """
-        url = Client.base_URL + "apps/match"
+        url = Client.base_URL + "cameras/exist"
         kwargs['type'] = camera_type
 
         # validate parameter names here.

--- a/pythonAPIClient/client.py
+++ b/pythonAPIClient/client.py
@@ -153,8 +153,6 @@ class Client(object):
         if response.status_code != 200:
             if response.status_code == 401:
                 raise AuthenticationError(response.json()['message'])
-            elif response.status_code == 404:
-                raise ResourceNotFoundError(response.json()['message'])
             elif response.status_code == 422:
                 raise FormatError(response.json()['message'])
             else:
@@ -251,8 +249,6 @@ class Client(object):
         if response.status_code != 200:
             if response.status_code == 401:
                 raise AuthenticationError(response.json()['message'])
-            elif response.status_code == 404:
-                raise ResourceNotFoundError(response.json()['message'])
             else:
                 raise InternalError()
         clientObject = response.json()
@@ -384,6 +380,9 @@ class Client(object):
 
         AuthenticationError
             If the client secret of this client object does not match the clientID.
+        ResourceNotFoundError
+            If the client id of this client object does not match any client
+            in the database.
         InternalError
             If there is an API internal error.
 
@@ -406,8 +405,6 @@ class Client(object):
         if response.status_code != 200:
             if response.status_code == 401:
                 raise AuthenticationError(response.json()['message'])
-            elif response.status_code == 404:
-                raise ResourceNotFoundError(response.json()['message'])
             elif response.status_code == 422:
                 raise FormatError(response.json()['message'])
             else:
@@ -451,6 +448,26 @@ class Client(object):
             List of camera objects that has the given retrieval method. If there ar eno cameras
             matches the provided retrieval information, an empty list will be returned.
 
+        Raises
+        ------
+        FormatError
+            If camera type is not valid.
+
+            or camera type is not provided.
+
+            or ip is not provided when the camera type is 'ip'.
+
+            or snapshot_url is not provided when the camera type is 'non_ip'.
+
+            or m3u8_url is not provided whe nthe camera ytpe is 'stream'.
+
+        AuthenticationError
+            If the client secret of this client object does not match the clientID.
+        ResourceNotFoundError
+            If the client id of this client object does not match any client
+            in the database.
+        InternalError
+            If there is an API internal error.
         """
         url = Client.base_URL + "cameras/exist"
         kwargs['type'] = camera_type
@@ -466,8 +483,6 @@ class Client(object):
             if response.status_code == 401:
                 raise AuthenticationError(response.json()['message'])
             elif response.status_code == 422:
-                raise FormatError(response.json()['message'])
-            elif response.status_code == 404:
                 raise FormatError(response.json()['message'])
             else:
                 raise InternalError()

--- a/pythonAPIClient/client.py
+++ b/pythonAPIClient/client.py
@@ -402,8 +402,8 @@ class Client(object):
         camera_type : str
             Type of the camera. Type can only be 'ip', 'non_ip', or 'stream'.
         ip : str, optional
-            [for IP camera] Ip address of the camera. Although marked as optional, this field is required
-            when the camera type is 'ip'.
+            [for IP camera] Ip address of the camera. Although marked as optional,
+            this field is required when the camera type is 'ip'.
         port : Int, optional
             [for IP camera] Port of the camera. If no port provided, it will be set to default 80.
         image_path : str, optional
@@ -411,11 +411,11 @@ class Client(object):
         video_path : str, optinal
             [for IP camera] Path to retrievae vidoe from the camera.
         snapshot_url : str, optional
-            [for non_IP camera] Url to retrieval image frames from the camera. Although marked as optional, this field is required
-            when the camera type is 'non_ip'.
+            [for non_IP camera] Url to retrieval image frames from the camera.
+            Although marked as optional, this field is required when the camera type is 'non_ip'.
         m3u8_url : str, optional
-            [for stream camera] Url to retrieval video stream from the camera. Although marked as optional, this field is required
-            when the camera type is 'stream'.
+            [for stream camera] Url to retrieval video stream from the camera.
+            Although marked as optional, this field is required when the camera type is 'stream'.
 
         Returns
         -------
@@ -424,29 +424,19 @@ class Client(object):
             matches the provided retrieval information, an empty list will be returned.
 
         """
-        # function locals() contain all local variables;
-        # use another variable param to build a dict in the first line of the method
-        # will catch all method parameters & their values without catching other local variables
-        # used in the method but not used in api call.
-
-        param = dict(locals())
-        param.pop('self')
         url = Client.base_URL + "apps/match"
+        kwargs['type'] = camera_type
 
         # validate parameter names here.
 
         if self.token is None:
             self.request_token()
         header = self.header_builder()
-        response = self._check_token(response=requests.get(url, headers=header, params=param),
-                                     flag='GET', url=url, params=param)
+        response = self._check_token(response=requests.get(url, headers=header, params=kwargs),
+                                     flag='GET', url=url, params=kwargs)
         if response.status_code != 200:
             if response.status_code == 401:
                 raise AuthenticationError(response.json()['message'])
-            elif response.status_code == 403:
-                raise AuthorizationError(response.json()['message'])
-            elif response.status_code == 404:
-                raise ResourceNotFoundError(response.json()['message'])
             elif response.status_code == 422:
                 raise FormatError(response.json()['message'])
             else:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1488,5 +1488,29 @@ class TestClient(unittest.TestCase):
                                              })
         self.assertEqual(1, mock_response.json.call_count)
 
+    @mock.patch('pythonAPIClient.client.requests.get')
+    def test_camera_exist_call_correct_resource_not_found_Error(self, mock_get):
+        clientID = '0' * 96
+        clientSecret = '0' * 71
+        client = Client(clientID, clientSecret)
+        client.token = 'CorrectToken'
+        mock_response = mock.Mock()
+        expected_dict = {
+            "message": "No app exist with this client id."
+        }
+        mock_response.json.return_value = expected_dict
+        mock_response.status_code = 422
+        mock_get.return_value = mock_response
+        url = self.base_URL + 'cameras/exist'
+        with self.assertRaises(FormatError):
+            client.check_cam_exist(camera_type='ip', image_path='test_url', video_path='test_url')
+        mock_get.assert_called_once_with(url, headers={'Authorization': 'Bearer CorrectToken'},
+                                         params={
+                                             'type': 'ip',
+                                             'image_path': 'test_url',
+                                             'video_path': 'test_url'
+                                             })
+        self.assertEqual(1, mock_response.json.call_count)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -277,7 +277,7 @@ class TestClient(unittest.TestCase):
         # in request token function.
         # which will only be called:
         # 1: when no token exists for the client object
-        # 2: when previdous token expires
+        # 2: when previous token expires
 
         # this testcase test for the first scenario.
         # the function exits before makeing the register api call.


### PR DESCRIPTION
also, several checking of 404 errors are removed. 
for many functions, the 404 errors are thrown in requesting token, but not in the actual corresponding route. In such case, the 404 error will be thrown by the request_token() function, and will not reach the calling function itself.