### PR TITLE
Camera implementation

### DIFF
--- a/CAM2CameraDatabaseAPIClient/camera.py
+++ b/CAM2CameraDatabaseAPIClient/camera.py
@@ -5,8 +5,7 @@ Represents a camera.
 class Camera(dict):
 
     """Class representing a general camera.
-    It inherits from dict and uses  all its methods as defined in dict.
-    Therefore, there's no need to define a constructor.
+
 
     Attributes
     ----------

--- a/CAM2CameraDatabaseAPIClient/camera.py
+++ b/CAM2CameraDatabaseAPIClient/camera.py
@@ -2,7 +2,7 @@
 Represents a camera.
 """
 
-class Camera(object):
+class Camera(dict):
 
     """Class representing a general camera.
     Attributes
@@ -31,7 +31,8 @@ class Camera(object):
     """
 
     def __init__(self, **dict_entries):
-        """Client initialization method.
+        """Camera constructor. It overrides dict's constructor's definition. It allows to use the underlying
+        data structure of python's builtin dict.
 
         Parameters
         ----------
@@ -44,10 +45,9 @@ class Camera(object):
             Camera should only be initialized by results returned from the API.
             Documentation of camera constructor is for CAM2 API team only.
         """
-        self.__dict__.update(dict_entries)
+        super().__init__(**dict_entries)
 
-    def __str__(self):
-        return str(self.__dict__)
+   
 
     @staticmethod
     def process_json(**dict_entries):

--- a/CAM2CameraDatabaseAPIClient/camera.py
+++ b/CAM2CameraDatabaseAPIClient/camera.py
@@ -31,8 +31,8 @@ class Camera(dict):
     """
 
     def __init__(self, **dict_entries):
-        """Camera constructor. It overrides dict's constructor's definition. It allows to use the underlying
-        data structure of python's builtin dict.
+        """Camera constructor. It overrides dict's constructor's definition.
+        It allows to use the underlying data structure of python's builtin dict.
 
         Parameters
         ----------
@@ -46,8 +46,6 @@ class Camera(dict):
             Documentation of camera constructor is for CAM2 API team only.
         """
         super().__init__(**dict_entries)
-
-   
 
     @staticmethod
     def process_json(**dict_entries):

--- a/CAM2CameraDatabaseAPIClient/camera.py
+++ b/CAM2CameraDatabaseAPIClient/camera.py
@@ -5,6 +5,9 @@ Represents a camera.
 class Camera(dict):
 
     """Class representing a general camera.
+    It inherits from dict and uses  all its methods as defined in dict. Therefore, there's no need to define
+    a constructor.
+
     Attributes
     ----------
     cameraID : str
@@ -29,24 +32,6 @@ class Camera(dict):
     reference_logo : str, optional
     reference_url : str, optional
     """
-
-    def __init__(self, **dict_entries):
-        """Camera constructor. It overrides dict's constructor's definition.
-        It allows to use the underlying data structure of python's builtin dict.
-
-        Parameters
-        ----------
-        dict_entries: dict
-            Dictionary of all field values of a camera.
-
-        Note
-        ----
-            User should not construct any camera object on his/her own.
-            Camera should only be initialized by results returned from the API.
-            Documentation of camera constructor is for CAM2 API team only.
-        """
-        super().__init__(**dict_entries)
-
     @staticmethod
     def process_json(**dict_entries):
         dict_entries['camera_type'] = dict_entries['type']

--- a/CAM2CameraDatabaseAPIClient/camera.py
+++ b/CAM2CameraDatabaseAPIClient/camera.py
@@ -5,8 +5,8 @@ Represents a camera.
 class Camera(dict):
 
     """Class representing a general camera.
-    It inherits from dict and uses  all its methods as defined in dict. Therefore, there's no need to define
-    a constructor.
+    It inherits from dict and uses  all its methods as defined in dict.
+    Therefore, there's no need to define a constructor.
 
     Attributes
     ----------

--- a/CAM2CameraDatabaseAPIClient/tests/test_camera.py
+++ b/CAM2CameraDatabaseAPIClient/tests/test_camera.py
@@ -72,7 +72,6 @@ class TestCamera(unittest.TestCase):
             'model': 'test_model',
             'image_path': 'test_image',
             'video_path': None})
-        print(ip_attr)
 
         ip_cam_test = IPCamera(**ip_attr)
 

--- a/CAM2CameraDatabaseAPIClient/tests/test_camera.py
+++ b/CAM2CameraDatabaseAPIClient/tests/test_camera.py
@@ -2,7 +2,7 @@
 This class holds the code to test camera objects.
 """
 import unittest
-import sys
+import sys, random
 from os import path
 from CAM2CameraDatabaseAPIClient.camera import Camera, IPCamera, NonIPCamera, StreamCamera
 
@@ -80,6 +80,38 @@ class TestCamera(unittest.TestCase):
         self.assertTrue(issubclass(ip_cam_test.__class__, Camera))
 
         self.assertEqual(ip_cam_test, ip_attr)
+
+    def test_getitem(self):
+
+        cam = Camera(**self.cam_attr)
+
+        self.assertTrue(hasattr(cam , '__getitem__'))
+
+        for k, v in self.cam_attr.items():
+            self.assertEqual(v, cam.get(k), 'Failed to get attribute {0}'.format(k))
+            self.assertEqual(v, cam[k], 'Failed to index attribute {0}'.format(k))
+
+    def test_setitem(self):
+
+
+        cam = Camera(**self.cam_attr)
+        self.assertTrue(hasattr(cam, '__setitem__'))
+
+        for k,v in self.cam_attr.items():
+            x = random.random()
+            cam[k] = x
+            self.assertEqual(x, cam[k], 'Failed to set attribute {0}'.format(k))
+
+
+    def test_iter(self):
+
+        cam = Camera(**self.cam_attr)  # will mutate it
+        self.assertTrue(hasattr(cam, '__iter__'))
+
+        testing_dict = dict(**self.cam_attr)
+        self.assertEqual(list(cam.__iter__()), list(testing_dict.__iter__()))
+
+
 
 
 

--- a/CAM2CameraDatabaseAPIClient/tests/test_camera.py
+++ b/CAM2CameraDatabaseAPIClient/tests/test_camera.py
@@ -105,11 +105,13 @@ class TestCamera(unittest.TestCase):
 
     def test_iter(self):
 
-        cam = Camera(**self.cam_attr)  # will mutate it
+        cam = Camera(**self.cam_attr)
         self.assertTrue(hasattr(cam, '__iter__'))
 
         testing_dict = dict(**self.cam_attr)
         self.assertEqual(list(cam.__iter__()), list(testing_dict.__iter__()))
+
+
 
 
 

--- a/CAM2CameraDatabaseAPIClient/tests/test_camera.py
+++ b/CAM2CameraDatabaseAPIClient/tests/test_camera.py
@@ -2,7 +2,8 @@
 This class holds the code to test camera objects.
 """
 import unittest
-import sys, random
+import sys
+import random
 from os import path
 from CAM2CameraDatabaseAPIClient.camera import Camera, IPCamera, NonIPCamera, StreamCamera
 
@@ -63,7 +64,7 @@ class TestCamera(unittest.TestCase):
 
         self.cam_attr.pop('m3u8_url')
 
-    def test_non_ip_cam_init(self):
+    def test_ip_cam_init(self):
         ip_attr = dict(self.cam_attr)
         ip_attr.update({
             'ip': '127.0.0.1',
@@ -85,7 +86,7 @@ class TestCamera(unittest.TestCase):
 
         cam = Camera(**self.cam_attr)
 
-        self.assertTrue(hasattr(cam , '__getitem__'))
+        self.assertTrue(hasattr(cam, '__getitem__'))
 
         for k, v in self.cam_attr.items():
             self.assertEqual(v, cam.get(k), 'Failed to get attribute {0}'.format(k))
@@ -97,7 +98,7 @@ class TestCamera(unittest.TestCase):
         cam = Camera(**self.cam_attr)
         self.assertTrue(hasattr(cam, '__setitem__'))
 
-        for k,v in self.cam_attr.items():
+        for k in self.cam_attr.keys():
             x = random.random()
             cam[k] = x
             self.assertEqual(x, cam[k], 'Failed to set attribute {0}'.format(k))

--- a/CAM2CameraDatabaseAPIClient/tests/test_camera.py
+++ b/CAM2CameraDatabaseAPIClient/tests/test_camera.py
@@ -5,16 +5,14 @@ import unittest
 import sys
 from os import path
 from CAM2CameraDatabaseAPIClient.camera import Camera, IPCamera, NonIPCamera, StreamCamera
+
 sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 
 class TestCamera(unittest.TestCase):
 
     def setUp(self):
-        pass
-
-    def test_cam_init(self):
-        cam_attr = {
+        self.cam_attr = {
             'cameraID': 'test',
             'legacy_cameraID': 1,
             'camera_type': 'ip',
@@ -34,40 +32,57 @@ class TestCamera(unittest.TestCase):
             'reference_logo': None,
             'reference_url': None
         }
-        cam = Camera(**cam_attr)
+
+    def test_cam_init(self):
+        cam = Camera(**self.cam_attr)
         self.assertTrue(isinstance(cam, Camera))
+        self.assertTrue(isinstance(cam, dict))
 
+    def test_non_ip_cam_init(self):
         non_ip_attr = {'snapshot_url': 'test_url'}
-        cam_attr.update(non_ip_attr)
-        non_ip_cam_test = NonIPCamera(**cam_attr)
+        self.cam_attr.update(non_ip_attr)
+        non_ip_cam_test = NonIPCamera(**self.cam_attr)
+
         self.assertTrue(isinstance(non_ip_cam_test, NonIPCamera))
-        self.assertTrue(issubclass(non_ip_cam_test.__class__, cam.__class__))
-        self.assertEqual(non_ip_cam_test.__dict__, cam_attr)
+        self.assertTrue(isinstance(non_ip_cam_test, dict))
+        self.assertTrue(issubclass(non_ip_cam_test.__class__, Camera))
 
-        cam_attr.pop('snapshot_url')
+        self.assertEqual(non_ip_cam_test, self.cam_attr)
+        self.cam_attr.pop('snapshot_url')
 
+    def test_stream_cam_init(self):
         stream_attr = {'m3u8_url': 'test_url'}
-        cam_attr.update(stream_attr)
-        stream_cam_test = StreamCamera(**cam_attr)
+        self.cam_attr.update(stream_attr)
+        stream_cam_test = StreamCamera(**self.cam_attr)
+
         self.assertTrue(isinstance(stream_cam_test, StreamCamera))
-        self.assertTrue(issubclass(stream_cam_test.__class__, cam.__class__))
-        self.assertEqual(stream_cam_test.__dict__, cam_attr)
+        self.assertTrue(isinstance(stream_cam_test, dict))
+        self.assertTrue(issubclass(stream_cam_test.__class__, Camera))
 
-        cam_attr.pop('m3u8_url')
+        self.assertEqual(stream_cam_test, self.cam_attr)
 
-        ip_attr = {
+        self.cam_attr.pop('m3u8_url')
+
+    def test_non_ip_cam_init(self):
+        ip_attr = dict(self.cam_attr)
+        ip_attr.update({
             'ip': '127.0.0.1',
             'port': 80,
             'brand': 'test_brand',
             'model': 'test_model',
             'image_path': 'test_image',
-            'video_path': None
-        }
-        cam_attr.update(ip_attr)
-        ip_cam_test = IPCamera(**cam_attr)
+            'video_path': None})
+        print(ip_attr)
+
+        ip_cam_test = IPCamera(**ip_attr)
+
         self.assertTrue(isinstance(ip_cam_test, IPCamera))
-        self.assertTrue(issubclass(ip_cam_test.__class__, cam.__class__))
-        self.assertEqual(ip_cam_test.__dict__, cam_attr)
+        self.assertTrue(isinstance(ip_cam_test, dict))
+        self.assertTrue(issubclass(ip_cam_test.__class__, Camera))
+
+        self.assertEqual(ip_cam_test, ip_attr)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/CAM2CameraDatabaseAPIClient/tests/test_camera.py
+++ b/CAM2CameraDatabaseAPIClient/tests/test_camera.py
@@ -113,6 +113,12 @@ class TestCamera(unittest.TestCase):
 
 
 
+    def test_pop(self):
+        cam = Camera(**self.cam_attr)
+        self.assertTrue(hasattr(cam, 'pop'))
+
+        for k, v in self.cam_attr.items():
+            self.assertEqual(v, cam.pop(k), 'Failed to pop attribute {0}'.format(k))
 
 
 

--- a/CAM2CameraDatabaseAPIClient/tests/test_camera.py
+++ b/CAM2CameraDatabaseAPIClient/tests/test_camera.py
@@ -98,7 +98,7 @@ class TestCamera(unittest.TestCase):
         cam = Camera(**self.cam_attr)
         self.assertTrue(hasattr(cam, '__setitem__'))
 
-        for k in self.cam_attr.keys():
+        for k in self.cam_attr:
             x = random.random()
             cam[k] = x
             self.assertEqual(x, cam[k], 'Failed to set attribute {0}'.format(k))

--- a/CAM2CameraDatabaseAPIClient/tests/test_client.py
+++ b/CAM2CameraDatabaseAPIClient/tests/test_client.py
@@ -814,7 +814,7 @@ class GetCamIDTest(BaseClientTest):
         mock_response.json.return_value = mock_dict
         mock_response.status_code = 200
         mock_get.return_value = mock_response
-        self.assertEqual(self.client.camera_by_id('12345').__dict__, expected_dict)
+        self.assertEqual(self.client.camera_by_id('12345'), expected_dict)
         mock_get.assert_called_once_with(self.url, headers=self.header)
 
     @mock.patch('CAM2CameraDatabaseAPIClient.client.requests.get')
@@ -850,7 +850,7 @@ class GetCamIDTest(BaseClientTest):
         }
         mock_response3.json.return_value = mock_dict
         mock_get.side_effect = [mock_response, mock_response2, mock_response3]
-        self.assertEqual(self.client.camera_by_id('12345').__dict__, expected_dict)
+        self.assertEqual(self.client.camera_by_id('12345'), expected_dict)
         self.assertEqual(3, mock_get.call_count)
         headers = {'Authorization': 'Bearer ExpiredToken'}
         call_list = [mock.call(self.url, headers=headers),
@@ -1172,7 +1172,7 @@ class SearchCamTest(BaseClientTest):
                        "reference_url":"http://some_url", "cameraID":"5b0e74213651360004edb426",
                        "snapshot_url":"http://images./preview/adf.jpg",
                        "latitude":35.8876, "longitude":136.098}
-        self.assertEqual(response_list[0].__dict__, actual_dict,
+        self.assertEqual(response_list[0], actual_dict,
                          'Returned json is not tranlated correctly')
 
     def test_search_camera_only_illegal_args(self):

--- a/CAM2CameraDatabaseAPIClient/tests/test_client.py
+++ b/CAM2CameraDatabaseAPIClient/tests/test_client.py
@@ -963,7 +963,7 @@ class SearchCamTest(BaseClientTest):
         cam = NonIPCamera(**cam_entries)
         actual_list = [cam] * 100
         for i in range(100):
-            self.assertEqual(response_list[i].__dict__, actual_list[i].__dict__)
+            self.assertEqual(response_list[i], actual_list[i])
         return response_list
 
     @mock.patch('CAM2CameraDatabaseAPIClient.client.requests.get')
@@ -1232,7 +1232,7 @@ class CamExistTest(BaseClientTest):
         cam = NonIPCamera(**cam_entries)
         actual_list = [cam] * 2
         for i in range(2):
-            self.assertEqual(response_list[i].__dict__, actual_list[i].__dict__)
+            self.assertEqual(response_list[i], actual_list[i])
 
     @mock.patch('CAM2CameraDatabaseAPIClient.client.requests.get')
     def test_camera_exist_all_correct_empty(self, mock_get):


### PR DESCRIPTION
I added the implementation for cameras.py discussed during the meeting. It now inherits from dict built in class. 

I modified the test cases and split them to reflect what functionality each function is testing. 
In each test_init function I tested whether the object created is also an instance of dict. 
I added a few function to test whether the common functionalities of dict are working or not.
test_getitem(self): tests get() and indexing operator
test_setitem(self): tests whether you can change the items the way you do with a dict
test_iter(self):   tests if the iterator created when you iterate over the cam object is the same as when you iterate over a dict.
test_pop(self): tests the pop() function

NOTES:
I edited the test_client.py to reflect new changes to camera object. I specifically removed comparison with __dict__ attributes. 

It turns out there's no need to redefine __init__ if it's just calling the parent's constructor.

